### PR TITLE
fixes to broken declarations missed by tests

### DIFF
--- a/core/debug.d.ts
+++ b/core/debug.d.ts
@@ -192,10 +192,17 @@ declare namespace debug {
      * Sets the metatable for the given value to the given table (which can be
      * nil). Returns value.
      */
-    function setmetatable<T, TIndex>(
+    function setmetatable<
+        T extends object,
+        TIndex extends object | ((this: T, key: any) => any) | undefined = undefined
+    >(
         value: T,
-        table: LuaMetatable<T & TIndex, TIndex> | null | undefined
-    ): T & TIndex;
+        table?: LuaMetatable<T, TIndex> | null
+    ): TIndex extends (this: T, key: infer TKey) => infer TValue
+        ? T & { [K in TKey & string]: TValue }
+        : TIndex extends object
+        ? T & TIndex
+        : T;
 
     /**
      * This function assigns the value value to the upvalue with index up of the

--- a/core/metatable.d.ts
+++ b/core/metatable.d.ts
@@ -1,6 +1,12 @@
 // Based on https://www.lua.org/manual/5.3/manual.html#2.4
 
-interface LuaMetatable<T, TIndex extends object | ((this: T, key: any) => any) | undefined> {
+interface LuaMetatable<
+    T,
+    TIndex extends object | ((this: T, key: any) => any) | undefined =
+        | object
+        | ((this: T, key: any) => any)
+        | undefined
+> {
     /**
      * the addition (+) operation. If any operand for an addition is not a number
      * (nor a string coercible to a number), Lua will try to call a metamethod.


### PR DESCRIPTION
This fixes broken declarations that prevent compiling of programs using lua-types.

It does not address the issue of tests not properly detecting broken declarations. That needs to be investigated further.
