### PR TITLE
Make pairs return non-nullable values for LuaTable iteration too

### DIFF
--- a/core/global.d.ts
+++ b/core/global.d.ts
@@ -124,7 +124,7 @@ declare function getmetatable<T>(object: T): LuaMetatable<T> | undefined;
  * will iterate over the key–value pairs (1,t[1]), (2,t[2]), ..., up to the
  * first nil value.
  */
-declare function ipairs<T>(t: Record<number, T>): LuaIterable<LuaMultiReturn<[number, T]>>;
+declare function ipairs<T>(t: Record<number, T>): LuaIterable<LuaMultiReturn<[number, NonNullable<T>]>>;
 
 /**
  * Allows a program to traverse all fields of a table. Its first argument is a
@@ -160,7 +160,7 @@ declare function next(table: object, index?: any): LuaMultiReturn<[any, any] | [
 declare function pairs<TKey, TValue>(
     t: LuaTable<TKey, TValue>
 ): LuaIterable<LuaMultiReturn<[TKey, TValue]>>;
-declare function pairs<T>(t: T): LuaIterable<LuaMultiReturn<[keyof T, T[keyof T]]>>;
+declare function pairs<T>(t: T): LuaIterable<LuaMultiReturn<[keyof T, NonNullable<T[keyof T]>]>>;
 
 /**
  * Calls function f with the given arguments in protected mode. This means that

--- a/core/global.d.ts
+++ b/core/global.d.ts
@@ -124,7 +124,9 @@ declare function getmetatable<T>(object: T): LuaMetatable<T> | undefined;
  * will iterate over the key–value pairs (1,t[1]), (2,t[2]), ..., up to the
  * first nil value.
  */
-declare function ipairs<T>(t: Record<number, T>): LuaIterable<LuaMultiReturn<[number, NonNullable<T>]>>;
+declare function ipairs<T>(
+    t: Record<number, T>
+): LuaIterable<LuaMultiReturn<[number, NonNullable<T>]>>;
 
 /**
  * Allows a program to traverse all fields of a table. Its first argument is a

--- a/core/global.d.ts
+++ b/core/global.d.ts
@@ -161,7 +161,7 @@ declare function next(table: object, index?: any): LuaMultiReturn<[any, any] | [
  */
 declare function pairs<TKey, TValue>(
     t: LuaTable<TKey, TValue>
-): LuaIterable<LuaMultiReturn<[TKey, TValue]>>;
+): LuaIterable<LuaMultiReturn<[TKey, NonNullable<TValue>]>>;
 declare function pairs<T>(t: T): LuaIterable<LuaMultiReturn<[keyof T, NonNullable<T[keyof T]>]>>;
 
 /**


### PR DESCRIPTION
Also for #29. Useful if you want your LuaTable to have stricter null/nil checking.