### PR TITLE
removing all nulls in favor of just being undefined

### DIFF
--- a/core/debug.d.ts
+++ b/core/debug.d.ts
@@ -197,7 +197,7 @@ declare namespace debug {
         TIndex extends object | ((this: T, key: any) => any) | undefined = undefined
     >(
         value: T,
-        table?: LuaMetatable<T, TIndex> | null
+        table?: LuaMetatable<T, TIndex>
     ): TIndex extends (this: T, key: infer TKey) => infer TValue
         ? T & { [K in TKey & string]: TValue }
         : TIndex extends object
@@ -227,8 +227,8 @@ declare namespace debug {
      * level to start the traceback (default is 1, the function calling
      * traceback).
      */
-    function traceback(message?: string | null, level?: number | null): string;
-    function traceback(thread?: LuaThread, message?: string | null, level?: number | null): string;
+    function traceback(message?: string, level?: number): string;
+    function traceback(thread?: LuaThread, message?: string, level?: number): string;
     function traceback<T>(message: T): T;
     function traceback<T>(thread: LuaThread, message: T): T;
 }

--- a/core/global.d.ts
+++ b/core/global.d.ts
@@ -25,11 +25,11 @@ declare const _G: typeof globalThis;
  * otherwise, returns all its arguments. In case of error, `message` is the
  * error object; when absent, it defaults to "assertion failed!"
  */
-declare function assert<V>(v: V): Exclude<V, undefined | null | false>;
+declare function assert<V>(v: V): Exclude<V, undefined | false>;
 declare function assert<V, A extends any[]>(
     v: V,
     ...args: A
-): LuaMultiReturn<[Exclude<V, undefined | null | false>, ...A]>;
+): LuaMultiReturn<[Exclude<V, undefined | false>, ...A]>;
 
 /**
  * This function is a generic interface to the garbage collector. It performs
@@ -248,7 +248,7 @@ declare function setmetatable<
     TIndex extends object | ((this: T, key: any) => any) | undefined = undefined
 >(
     table: T,
-    metatable?: LuaMetatable<T, TIndex> | null
+    metatable?: LuaMetatable<T, TIndex>
 ): TIndex extends (this: T, key: infer TKey) => infer TValue
     ? T & { [K in TKey & string]: TValue }
     : TIndex extends object

--- a/special/5.1-only.d.ts
+++ b/special/5.1-only.d.ts
@@ -13,7 +13,7 @@
  * When absent, it defaults to "=(load)".
  */
 declare function load(
-    func: () => string | null | undefined,
+    func?: () => string,
     chunkname?: string
 ): LuaMultiReturn<[() => any] | [undefined, string]>;
 

--- a/special/5.2-plus-or-jit.d.ts
+++ b/special/5.2-plus-or-jit.d.ts
@@ -32,7 +32,7 @@
  * binary chunks can crash the interpreter.
  */
 declare function load(
-    chunk: string | (() => string | null | undefined),
+    chunk: string | (() => string | undefined),
     chunkname?: string,
     mode?: 'b' | 't' | 'bt',
     env?: object

--- a/special/jit-only.d.ts
+++ b/special/jit-only.d.ts
@@ -32,7 +32,7 @@
  * binary chunks can crash the interpreter.
  */
 declare function loadstring(
-    chunk: string | (() => string | null | undefined),
+    chunk: string | (() => string | undefined),
     chunkname?: string,
     mode?: 'b' | 't' | 'bt',
     env?: object


### PR DESCRIPTION
this more accurately represents what is happening in Lua, and allows null to be represented by something else in TSTL