### PR TITLE
Fix missing not nil constraint for pairs keys for 5.0

### DIFF
--- a/core/5.0/global.d.ts
+++ b/core/5.0/global.d.ts
@@ -102,7 +102,7 @@ declare function next(table: object, index?: any): LuaMultiReturn<[any, any] | [
  * See function next for the caveats of modifying the table during its
  * traversal.
  */
-declare function pairs<TKey, TValue>(
+declare function pairs<TKey extends AnyNotNil, TValue>(
     t: LuaTable<TKey, TValue>
 ): LuaIterable<LuaMultiReturn<[TKey, NonNullable<TValue>]>>;
 declare function pairs<T>(t: T): LuaIterable<LuaMultiReturn<[keyof T, NonNullable<T[keyof T]>]>>;


### PR DESCRIPTION
Like #74, but for Lua 5.0.