### PR TITLE
5.0: Restore missing math.mod() function

### DIFF
--- a/core/5.0/math.d.ts
+++ b/core/5.0/math.d.ts
@@ -96,6 +96,12 @@ declare namespace math {
     function min(x: number, ...numbers: number[]): number;
 
     /**
+     * Returns the remainder of the division of x by y that rounds the quotient
+     * towards zero. (integer/float)
+     */
+    function mod(x: number, y: number): number;
+
+    /**
      * The value of π.
      */
     const pi: number;


### PR DESCRIPTION
It's the contemporary math.fmod() but renamed, wasn't aware of that, whoops.