### PR TITLE
Fix string.find and string.match from unexpected explosions

### DIFF
--- a/core/5.0/string.d.ts
+++ b/core/5.0/string.d.ts
@@ -61,7 +61,7 @@ declare namespace string {
         pattern: string,
         init?: number,
         plain?: boolean
-    ): LuaMultiReturn<[number, number, ...string[]] | []>;
+    ): LuaMultiReturn<[number?, number?, ...string[]] | []>;
 
     /**
      * Returns a formatted version of its variable number of arguments following

--- a/core/string.d.ts
+++ b/core/string.d.ts
@@ -62,7 +62,7 @@ declare namespace string {
         pattern: string,
         init?: number,
         plain?: boolean
-    ): LuaMultiReturn<[number, number, ...string[]] | []>;
+    ): LuaMultiReturn<[number?, number?, ...string[]] | []>;
 
     /**
      * Returns a formatted version of its variable number of arguments following

--- a/core/string.d.ts
+++ b/core/string.d.ts
@@ -177,7 +177,7 @@ declare namespace string {
      * returned. A third, optional numeric argument init specifies where to start
      * the search; its default value is 1 and can be negative.
      */
-    function match(s: string, pattern: string, init?: number): LuaMultiReturn<string[]>;
+    function match(s: string, pattern: string, init?: number): LuaMultiReturn<[string[] | null]>;
 
     /**
      * Returns a string that is the concatenation of `n` copies of the string `s`.


### PR DESCRIPTION
I was reading the documentation for ``string.find`` and I noticed that in it's own documentation it reads: 
```
/**
  * Looks for the first match of pattern (see §6.4.1) in the string s. If it
  * finds a match, then find returns the indices of s where this occurrence
  * starts and ends; otherwise, it returns nil.
  * /
```
I see the definition defined as:
```ts
function find(
    s: string,
    pattern: string,
    init?: number,
    plain?: boolean
): LuaMultiReturn<[number, number, ...string[]] | []> ;
```
Perhaps the easiest solution for this would be to simply add optional return parameters as follows:
```
function find(
    s: string,
    pattern: string,
    init?: number,
    plain?: boolean
): LuaMultiReturn<[number?, number?, ...string[]] | []> ;
```
So this way, at least you know it might explode instead of blindly walking into an explosion.

**Also:**
I noticed that string.match could also blow up so I threw that in there.